### PR TITLE
Adds an ability to configure default upgrader and dialer

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,16 @@
+### Description
+<!--- 
+Replace this comment with a description of the problem.
+
+Please help us by providing all of the details listed below. A complete and thoughtful issue request with research on possible root causes and diagnostics goes a very long way in helping us rapidly get your issues resolved.
+
+COMMITTERS: please include labels on each issue. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind` and `status` labels.
+--> 
+
+### Reproduction Steps
+<!-- Describe the issue in as much detail as possible including steps to reproduce. Screenshots are very helpful. -->
+
+**OS and version:**    
+
+**Diagnostics:** 
+<!-- Provide logs and any other relevant diagnostic information -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+<!-- Please review the following before submitting a PR:
+Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
+Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
+
+COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
+-->
+
+### What does this PR do?
+
+
+### What issues does this PR fix or reference?
+
+<!-- #### Changelog -->
+<!-- The changelog will be pulled from the PR's title. 
+     Please provide a clear and meaningful title to the PR and don't include issue number -->
+
+
+#### Release Notes
+<!-- markdown to be included in marketing announcement - N/A for bugs -->
+
+
+#### Docs PR
+<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
+Both will be merged at the same time. -->

--- a/jsonrpcws/jsonrpc_impl.go
+++ b/jsonrpcws/jsonrpc_impl.go
@@ -41,13 +41,19 @@ import (
 )
 
 var (
-	defaultUpgrader = &websocket.Upgrader{
+	// default upgrader that is used for upgrading http connection to WebSocket
+	// may be changed by client if custom settings are needed
+	DefaultUpgrader = &websocket.Upgrader{
 		ReadBufferSize:  1024,
 		WriteBufferSize: 1024,
 		CheckOrigin: func(r *http.Request) bool {
 			return true
 		},
 	}
+
+	// default dialer that is used for WebSocket connection establishing
+	// may be changed by client if custom settings are needed
+    DefaultDialer = websocket.DefaultDialer
 )
 
 // Dial establishes a new client WebSocket connection.
@@ -59,7 +65,7 @@ func Dial(url string, token string) (*NativeConnAdapter, error) {
 		headers = make(map[string][]string)
 		headers.Add("Authorization", token)
 	}
-	conn, _, err := websocket.DefaultDialer.Dial(url, headers)
+	conn, _, err := DefaultDialer.Dial(url, headers)
 	if err != nil {
 		return nil, err
 	}
@@ -68,7 +74,7 @@ func Dial(url string, token string) (*NativeConnAdapter, error) {
 
 // Upgrade upgrades http connection to WebSocket connection.
 func Upgrade(w http.ResponseWriter, r *http.Request) (*NativeConnAdapter, error) {
-	conn, err := defaultUpgrader.Upgrade(w, r, nil)
+	conn, err := DefaultUpgrader.Upgrade(w, r, nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
 ### What does this PR do?
Adds an ability to configure default upgrader and dialer.
The example of a case when it is needed: configuring custom certificate trust store.
```go
    ...
    // Trust the configured cert pool in our client
    jsonrpcws.DefaultDialer.TLSClientConfig = &tls.Config{
	RootCAs:            rootCAs,
    }
    jsonrpcws.Dial(endpoint, token)
    ...    
```

### What issues does this PR fix or reference?
It is related to the following issue https://github.com/eclipse/che/issues/10910
It is needed for https://github.com/eclipse/che/pull/12089

#### Release Notes
N/A

#### Docs PR
N/A